### PR TITLE
Add WrapAll() with required signal for Wrap()

### DIFF
--- a/signalcontext.go
+++ b/signalcontext.go
@@ -14,17 +14,32 @@ import (
 
 // OnInterrupt creates a new context that cancels on SIGINT or SIGTERM.
 func OnInterrupt() (context.Context, func()) {
-	return Wrap(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	return wrap(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 }
 
 // On creates a new context that cancels on the given signals.
-func On(signals ...os.Signal) (context.Context, func()) {
-	return Wrap(context.Background(), signals...)
+func On(sig os.Signal, signals ...os.Signal) (context.Context, func()) {
+	return wrap(context.Background(), append(signals, sig)...)
+}
+
+// OnAll creates a new context that cancels on all supported signals.
+func OnAll() (context.Context, func()) {
+	return wrap(context.Background())
 }
 
 // Wrap creates a new context that cancels on the given signals. It wraps the
 // provided context.
-func Wrap(ctx context.Context, signals ...os.Signal) (context.Context, func()) {
+func Wrap(ctx context.Context, sig os.Signal, signals ...os.Signal) (context.Context, func()) {
+	return wrap(ctx, append(signals, sig)...)
+}
+
+// WrapAll creates a new context that cancels on all supported signals. It wraps the
+// provided context.
+func WrapAll(ctx context.Context) (context.Context, func()) {
+	return wrap(ctx)
+}
+
+func wrap(ctx context.Context, signals ...os.Signal) (context.Context, func()) {
 	ctx, closer := context.WithCancel(ctx)
 
 	c := make(chan os.Signal, 1)

--- a/signalcontext_test.go
+++ b/signalcontext_test.go
@@ -43,7 +43,7 @@ func TestWrapAll(t *testing.T) {
 	case <-time.After(10 * time.Millisecond):
 	}
 
-	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINFO); err != nil {
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGUSR2); err != nil {
 		t.Fatal("failed to signal")
 	}
 

--- a/signalcontext_test.go
+++ b/signalcontext_test.go
@@ -33,6 +33,28 @@ func TestWrap(t *testing.T) {
 	}
 }
 
+func TestWrapAll(t *testing.T) {
+	ctx, cancel := signalcontext.WrapAll(context.Background())
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("context should not be done")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINFO); err != nil {
+		t.Fatal("failed to signal")
+	}
+
+	select {
+	case <-ctx.Done():
+		// expected
+	case <-time.After(10 * time.Millisecond):
+		t.Fatal("context should have been done")
+	}
+}
+
 func ExampleOnInterrupt() {
 	ctx, cancel := signalcontext.OnInterrupt()
 	defer cancel()


### PR DESCRIPTION
This enforces to provide at least 1 signal to `Wrap()` and `On()` methods to avoid [Notify(AllSignals)](https://golang.org/pkg/os/signal/#example_Notify_allSignals) implicit pattern.
Use `WrapAll()` and `OnAll()` methods to react to all signals if needed.